### PR TITLE
Add compound 'ap'

### DIFF
--- a/src/human_parse.cpp
+++ b/src/human_parse.cpp
@@ -246,5 +246,5 @@ human_parse::human_parse(){
   compounds.insert("bin");
   compounds.insert("ben");
   compounds.insert("ibn");
-  
+  compounds.insert("ap");
 }


### PR DESCRIPTION
A very tiny addition. 'ap' is a somewhat old-fashioned (but still sometimes seen) Welsh patronymic form
